### PR TITLE
Support const char* keys

### DIFF
--- a/verstable.h
+++ b/verstable.h
@@ -775,9 +775,9 @@ VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _init_clone )(
   #endif
 );
 
-VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _size )( NAME * );
+VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _size )( const NAME * );
 
-VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _bucket_count )( NAME * );
+VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _bucket_count )( const NAME * );
 
 VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _is_end )( VT_CAT( NAME, _itr ) );
 
@@ -983,12 +983,12 @@ VT_API_FN_QUALIFIERS bool VT_CAT( NAME, _init_clone )(
   return true;
 }
 
-VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _size )( NAME *table )
+VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _size )( const NAME *table )
 {
   return table->key_count;
 }
 
-VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _bucket_count )( NAME *table )
+VT_API_FN_QUALIFIERS size_t VT_CAT( NAME, _bucket_count )( const NAME *table )
 {
   // If the bucket count is zero, buckets_mask will be zero, not the bucket count minus one.
   // We account for this special case by adding (bool)buckets_mask rather than one.
@@ -1757,12 +1757,12 @@ static inline bool VT_CAT( vt_init_clone_, VT_TEMPLATE_COUNT )(
   );
 }
 
-static inline size_t VT_CAT( vt_size_, VT_TEMPLATE_COUNT )( NAME *table )
+static inline size_t VT_CAT( vt_size_, VT_TEMPLATE_COUNT )( const NAME *table )
 {
   return VT_CAT( NAME, _size )( table );
 }
 
-static inline size_t VT_CAT( vt_bucket_count_, VT_TEMPLATE_COUNT )( NAME *table )
+static inline size_t VT_CAT( vt_bucket_count_, VT_TEMPLATE_COUNT )( const NAME *table )
 {
   return VT_CAT( NAME, _bucket_count )( table );
 }


### PR DESCRIPTION
The builtin hash and comparison functions now mark their arguments as const, which they should have been doing anyway.

In addition, automatic deduction of hash and cmpr functions now works for const char* keys.

Fixes #12